### PR TITLE
TextStyle > BoxShadow 콤마 중복 수정

### DIFF
--- a/src/text_style.js
+++ b/src/text_style.js
@@ -87,7 +87,7 @@ export function toDart(context, textStyle, depth = 1, useName = true) {
     }
     
     if (textStyle.shadows != null) {
-        shadowElements = `\n${depthStr}shadows: ${boxShadows.toDart(context, textStyle.shadows)}`;
+        shadowElements = `\n${depthStr}shadows: ${boxShadows.toDart(context, textStyle.shadows, depth + 1)}`;
     }
 
     return `TextStyle(

--- a/src/text_style.js
+++ b/src/text_style.js
@@ -71,9 +71,6 @@ export function toDart(context, textStyle, depth = 1, useName = true) {
             fontStyleElement = `\n${depthStr}fontStyle: FontStyle.${textStyle.fontStyle},`;
         } 
     } 
-    if (textStyle.shadows != null) {
-        shadowElements = `\n${depthStr}shadows: ${boxShadows.toDart(context, textStyle.shadows)},`;
-    }
     
     if (textStyle.letterSpacing != null) {
        if (!options.skipLetterSpacing(context)) {
@@ -88,9 +85,13 @@ export function toDart(context, textStyle, depth = 1, useName = true) {
             }
         } 
     }
+    
+    if (textStyle.shadows != null) {
+        shadowElements = `\n${depthStr}shadows: ${boxShadows.toDart(context, textStyle.shadows)}`;
+    }
 
     return `TextStyle(
-${depthStr}color: ${color.toDart(context, textStyle.color, 1)},${fontSizeElement}${fontFamilyElement}${fontWeightElement}${fontStyleElement}${letterSpacingElement}${shadowElements}${lineHeightElement}
+${depthStr}color: ${color.toDart(context, textStyle.color, 1)},${fontSizeElement}${fontFamilyElement}${fontWeightElement}${fontStyleElement}${letterSpacingElement}${lineHeightElement}${shadowElements}
 ${endDepthStr})`;
 }
 


### PR DESCRIPTION
## 이슈
TextStyle 내 BoxShadow 뒤에 콤마가 두 개 들어가는 현상을 수정하였습니다.

<img width="170" alt="스크린샷 2020-02-21 오후 6 43 21" src="https://user-images.githubusercontent.com/12539719/75022855-29da5680-54da-11ea-9c4b-f2a8f0dac395.png">

## 해결
1) TextStyle 내에 BoxShadow의 위치를 맨 뒤로 이동하였습니다.
2) TextStyle 의 다른 프로퍼티와는 달리 BoxShadow 뒤에는 콤마를 붙이지 않도록 수정하였습니다.
3) BoxShadow의 indent도 수정하였습니다.
